### PR TITLE
test splinter's compressability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "half"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +367,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +391,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -507,6 +557,7 @@ dependencies = [
  "either",
  "itertools 0.14.0",
  "lz4",
+ "rand",
  "roaring",
  "thiserror",
  "zerocopy",
@@ -568,6 +619,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cc"
+version = "1.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +282,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "lz4"
+version = "1.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
+dependencies = [
+ "lz4-sys",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +486,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "smallvec"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +506,7 @@ dependencies = [
  "culprit",
  "either",
  "itertools 0.14.0",
+ "lz4",
  "roaring",
  "thiserror",
  "zerocopy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ itertools = "0.14"
 criterion = "=0.5.1"
 roaring = "=0.10.12"
 lz4 = "1.28.1"
+rand = "0.8.5"
 
 [[bench]]
 name = "bitmaps"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ itertools = "0.14"
 [dev-dependencies]
 criterion = "=0.5.1"
 roaring = "=0.10.12"
+lz4 = "1.28.1"
 
 [[bench]]
 name = "bitmaps"

--- a/README.md
+++ b/README.md
@@ -61,86 +61,107 @@ test                           bitmap         size   expected   relative        
 empty                          Splinter          8          8       1.00         ok
                                Roaring           8          8       1.00         ok
                                Splinter LZ4     13         13       1.62          >
+                               Roaring LZ4      13         13       1.00         ok
                                Baseline          0          0       0.00          <
 1 element                      Splinter         25         25       1.00         ok
                                Roaring          18         18       0.72          <
                                Splinter LZ4     18         18       0.72          <
+                               Roaring LZ4      20         20       1.11         ok
                                Baseline          4          4       0.16          <
 1 dense block                  Splinter         24         24       1.00         ok
                                Roaring         528        528      22.00         ok
                                Splinter LZ4     20         20       0.83          <
+                               Roaring LZ4     533        533      26.65         ok
                                Baseline       1024       1024      42.67         ok
 1 half full block              Splinter         56         56       1.00         ok
                                Roaring         272        272       4.86         ok
                                Splinter LZ4     26         26       0.46          <
+                               Roaring LZ4     276        276      10.62         ok
                                Baseline        512        512       9.14         ok
 1 sparse block                 Splinter         40         40       1.00         ok
                                Roaring          48         48       1.20         ok
                                Splinter LZ4     37         37       0.93          <
+                               Roaring LZ4      52         52       1.41         ok
                                Baseline         64         64       1.60         ok
 8 half full blocks             Splinter        308        308       1.00         ok
                                Roaring        2064       2064       6.70         ok
                                Splinter LZ4     70         70       0.23          <
+                               Roaring LZ4    2075       2075      29.64         ok
                                Baseline       4096       4096      13.30         ok
 8 sparse blocks                Splinter         68         68       1.00         ok
                                Roaring          48         48       0.71          <
                                Splinter LZ4     56         56       0.82          <
+                               Roaring LZ4      51         51       0.91          <
                                Baseline         64         64       0.94          <
 64 half full blocks            Splinter       2432       2432       1.00         ok
                                Roaring       16520      16520       6.79         ok
                                Splinter LZ4    117        117       0.05          <
+                               Roaring LZ4    1237       1237      10.57         ok
                                Baseline      32768      32768      13.47         ok
 64 sparse blocks               Splinter        512        512       1.00         ok
                                Roaring         392        392       0.77          <
                                Splinter LZ4     84         84       0.16          <
+                               Roaring LZ4     165        165       1.96         ok
                                Baseline        512        512       1.00         ok
 256 half full blocks           Splinter       9440       9440       1.00         ok
                                Roaring       65800      65800       6.97         ok
                                Splinter LZ4    178        178       0.02          <
+                               Roaring LZ4    2584       2584      14.52         ok
                                Baseline     131072     131072      13.88         ok
 256 sparse blocks              Splinter       1760       1760       1.00         ok
                                Roaring        1288       1288       0.73          <
                                Splinter LZ4    122        122       0.07          <
+                               Roaring LZ4     378        378       3.10         ok
                                Baseline       2048       2048       1.16         ok
 512 half full blocks           Splinter      18872      18872       1.00         ok
                                Roaring      131592     131592       6.97         ok
                                Splinter LZ4    232        232       0.01          <
+                               Roaring LZ4    3098       3098      13.35         ok
                                Baseline     262144     262144      13.89         ok
 512 sparse blocks              Splinter       3512       3512       1.00         ok
                                Roaring        2568       2568       0.73          <
                                Splinter LZ4    142        142       0.04          <
+                               Roaring LZ4     575        575       4.05         ok
                                Baseline       4096       4096       1.17         ok
 fully dense                    Splinter         84         84       1.00         ok
                                Roaring        8208       8208      97.71         ok
                                Splinter LZ4     44         44       0.52          <
+                               Roaring LZ4    8244       8244     187.36         ok
                                Baseline      16384      16384     195.05         ok
 128/block; dense               Splinter       1172       1172       1.00         ok
                                Roaring        8208       8208       7.00         ok
                                Splinter LZ4    121        121       0.10          <
+                               Roaring LZ4    8244       8244      68.13         ok
                                Baseline      16384      16384      13.98         ok
 32/block; dense                Splinter       4532       4532       1.00         ok
                                Roaring        8208       8208       1.81         ok
                                Splinter LZ4    322        322       0.07          <
+                               Roaring LZ4    8244       8244      25.60         ok
                                Baseline      16384      16384       3.62         ok
 16/block; dense                Splinter       4884       4884       1.00         ok
                                Roaring        8208       8208       1.68         ok
                                Splinter LZ4    580        580       0.12          <
+                               Roaring LZ4    8244       8244      14.21         ok
                                Baseline      16384      16384       3.35         ok
 128/block; sparse mid          Splinter       1358       1358       1.00         ok
                                Roaring        8456       8456       6.23         ok
                                Splinter LZ4    176        176       0.13          <
+                               Roaring LZ4     563        563       3.20         ok
                                Baseline      16384      16384      12.06         ok
 128/block; sparse high         Splinter       1544       1544       1.00         ok
                                Roaring        8456       8456       5.48         ok
                                Splinter LZ4    179        179       0.12          <
+                               Roaring LZ4     563        563       3.15         ok
                                Baseline      16384      16384      10.61         ok
 1/block; sparse mid            Splinter      21774      21774       1.00         ok
                                Roaring       10248      10248       0.47          <
                                Splinter LZ4   1191       1191       0.05          <
+                               Roaring LZ4    2138       2138       1.80         ok
                                Baseline      16384      16384       0.75          <
 1/block; sparse high           Splinter      46344      46344       1.00         ok
                                Roaring       40968      40968       0.88          <
                                Splinter LZ4   1313       1313       0.03          <
+                               Roaring LZ4   32931      32931      25.08         ok
                                Baseline      16384      16384       0.35          <
 ```
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,51 @@ fully dense                    Splinter         84         84       1.00        
                                Splinter LZ4  23910      23910       0.52          <
                                Roaring LZ4   41059      41059       1.72         ok
                                Baseline      16384      16384       0.35          <
+dense throughout               Splinter       6584       6584       1.00         ok
+                               Roaring        8712       8712       1.32         ok
+                               Splinter LZ4    154        154       0.02          <
+                               Roaring LZ4     691        691       4.49         ok
+                               Baseline      16384      16384       2.49         ok
+dense low                      Splinter       2292       2292       1.00         ok
+                               Roaring        8208       8208       3.58         ok
+                               Splinter LZ4    177        177       0.08          <
+                               Roaring LZ4    8240       8240      46.55         ok
+                               Baseline      16384      16384       7.15         ok
+dense mid/low                  Splinter       6350       6350       1.00         ok
+                               Roaring        8456       8456       1.33         ok
+                               Splinter LZ4    245        245       0.04          <
+                               Roaring LZ4     560        560       2.29         ok
+                               Baseline      16384      16384       2.58         ok
+random/32                      Splinter        546        546       1.00         ok
+                               Roaring         328        328       0.60          <
+                               Splinter LZ4    445        445       0.82          <
+                               Roaring LZ4     331        331       0.74          <
+                               Baseline        128        128       0.23          <
+random/256                     Splinter       3656       3656       1.00         ok
+                               Roaring        2568       2568       0.70          <
+                               Splinter LZ4   2734       2734       0.75          <
+                               Roaring LZ4    2576       2576       0.94          <
+                               Baseline       1024       1024       0.28          <
+random/1024                    Splinter      12530      12530       1.00         ok
+                               Roaring       10216      10216       0.82          <
+                               Splinter LZ4   7932       7932       0.63          <
+                               Roaring LZ4   10241      10241       1.29         ok
+                               Baseline       4096       4096       0.33          <
+random/4096                    Splinter      45594      45594       1.00         ok
+                               Roaring       39968      39968       0.88          <
+                               Splinter LZ4  25617      25617       0.56          <
+                               Roaring LZ4   40085      40085       1.56         ok
+                               Baseline      16384      16384       0.36          <
+random/16384                   Splinter     163970     163970       1.00         ok
+                               Roaring      148952     148952       0.91          <
+                               Splinter LZ4 101983     101983       0.62          <
+                               Roaring LZ4  149536     149536       1.47         ok
+                               Baseline      65536      65536       0.40          <
+random/65535                   Splinter     543929     543929       1.00         ok
+                               Roaring      462742     462742       0.85          <
+                               Splinter LZ4 358584     358584       0.66          <
+                               Roaring LZ4  464556     464556       1.30         ok
+                               Baseline     262140     262140       0.48          <
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -54,6 +54,96 @@ splinter
 
 ```
 
+## Comparison to Roaring
+
+```
+test                           bitmap         size   expected   relative         ok
+empty                          Splinter          8          8       1.00         ok
+                               Roaring           8          8       1.00         ok
+                               Splinter LZ4     13         13       1.62          >
+                               Baseline          0          0       0.00          <
+1 element                      Splinter         25         25       1.00         ok
+                               Roaring          18         18       0.72          <
+                               Splinter LZ4     18         18       0.72          <
+                               Baseline          4          4       0.16          <
+1 dense block                  Splinter         24         24       1.00         ok
+                               Roaring         528        528      22.00         ok
+                               Splinter LZ4     20         20       0.83          <
+                               Baseline       1024       1024      42.67         ok
+1 half full block              Splinter         56         56       1.00         ok
+                               Roaring         272        272       4.86         ok
+                               Splinter LZ4     26         26       0.46          <
+                               Baseline        512        512       9.14         ok
+1 sparse block                 Splinter         40         40       1.00         ok
+                               Roaring          48         48       1.20         ok
+                               Splinter LZ4     37         37       0.93          <
+                               Baseline         64         64       1.60         ok
+8 half full blocks             Splinter        308        308       1.00         ok
+                               Roaring        2064       2064       6.70         ok
+                               Splinter LZ4     70         70       0.23          <
+                               Baseline       4096       4096      13.30         ok
+8 sparse blocks                Splinter         68         68       1.00         ok
+                               Roaring          48         48       0.71          <
+                               Splinter LZ4     56         56       0.82          <
+                               Baseline         64         64       0.94          <
+64 half full blocks            Splinter       2432       2432       1.00         ok
+                               Roaring       16520      16520       6.79         ok
+                               Splinter LZ4    117        117       0.05          <
+                               Baseline      32768      32768      13.47         ok
+64 sparse blocks               Splinter        512        512       1.00         ok
+                               Roaring         392        392       0.77          <
+                               Splinter LZ4     84         84       0.16          <
+                               Baseline        512        512       1.00         ok
+256 half full blocks           Splinter       9440       9440       1.00         ok
+                               Roaring       65800      65800       6.97         ok
+                               Splinter LZ4    178        178       0.02          <
+                               Baseline     131072     131072      13.88         ok
+256 sparse blocks              Splinter       1760       1760       1.00         ok
+                               Roaring        1288       1288       0.73          <
+                               Splinter LZ4    122        122       0.07          <
+                               Baseline       2048       2048       1.16         ok
+512 half full blocks           Splinter      18872      18872       1.00         ok
+                               Roaring      131592     131592       6.97         ok
+                               Splinter LZ4    232        232       0.01          <
+                               Baseline     262144     262144      13.89         ok
+512 sparse blocks              Splinter       3512       3512       1.00         ok
+                               Roaring        2568       2568       0.73          <
+                               Splinter LZ4    142        142       0.04          <
+                               Baseline       4096       4096       1.17         ok
+fully dense                    Splinter         84         84       1.00         ok
+                               Roaring        8208       8208      97.71         ok
+                               Splinter LZ4     44         44       0.52          <
+                               Baseline      16384      16384     195.05         ok
+128/block; dense               Splinter       1172       1172       1.00         ok
+                               Roaring        8208       8208       7.00         ok
+                               Splinter LZ4    121        121       0.10          <
+                               Baseline      16384      16384      13.98         ok
+32/block; dense                Splinter       4532       4532       1.00         ok
+                               Roaring        8208       8208       1.81         ok
+                               Splinter LZ4    322        322       0.07          <
+                               Baseline      16384      16384       3.62         ok
+16/block; dense                Splinter       4884       4884       1.00         ok
+                               Roaring        8208       8208       1.68         ok
+                               Splinter LZ4    580        580       0.12          <
+                               Baseline      16384      16384       3.35         ok
+128/block; sparse mid          Splinter       1358       1358       1.00         ok
+                               Roaring        8456       8456       6.23         ok
+                               Splinter LZ4    176        176       0.13          <
+                               Baseline      16384      16384      12.06         ok
+128/block; sparse high         Splinter       1544       1544       1.00         ok
+                               Roaring        8456       8456       5.48         ok
+                               Splinter LZ4    179        179       0.12          <
+                               Baseline      16384      16384      10.61         ok
+1/block; sparse mid            Splinter      21774      21774       1.00         ok
+                               Roaring       10248      10248       0.47          <
+                               Splinter LZ4   1191       1191       0.05          <
+                               Baseline      16384      16384       0.75          <
+1/block; sparse high           Splinter      46344      46344       1.00         ok
+                               Roaring       40968      40968       0.88          <
+                               Splinter LZ4   1313       1313       0.03          <
+                               Baseline      16384      16384       0.35          <
+```
+
 ## License
 
 Licensed under either of

--- a/README.md
+++ b/README.md
@@ -60,108 +60,108 @@ splinter
 test                           bitmap         size   expected   relative         ok
 empty                          Splinter          8          8       1.00         ok
                                Roaring           8          8       1.00         ok
-                               Splinter LZ4     13         13       1.62          >
-                               Roaring LZ4      13         13       1.00         ok
+                               Splinter LZ4      9          9       1.12          >
+                               Roaring LZ4       9          9       1.00         ok
                                Baseline          0          0       0.00          <
 1 element                      Splinter         25         25       1.00         ok
                                Roaring          18         18       0.72          <
-                               Splinter LZ4     29         29       1.16          >
-                               Roaring LZ4      24         24       0.83          <
+                               Splinter LZ4     25         25       1.00          >
+                               Roaring LZ4      20         20       0.80          <
                                Baseline          4          4       0.16          <
 1 dense block                  Splinter         24         24       1.00         ok
                                Roaring         528        528      22.00         ok
-                               Splinter LZ4     28         28       1.17          >
-                               Roaring LZ4     536        536      19.14         ok
+                               Splinter LZ4     24         24       1.00          >
+                               Roaring LZ4     532        532      22.17         ok
                                Baseline       1024       1024      42.67         ok
 1 half full block              Splinter         56         56       1.00         ok
                                Roaring         272        272       4.86         ok
-                               Splinter LZ4     61         61       1.09          >
-                               Roaring LZ4     279        279       4.57         ok
+                               Splinter LZ4     57         57       1.02          >
+                               Roaring LZ4     275        275       4.82         ok
                                Baseline        512        512       9.14         ok
 1 sparse block                 Splinter         40         40       1.00         ok
                                Roaring          48         48       1.20         ok
-                               Splinter LZ4     45         45       1.12          >
-                               Roaring LZ4      54         54       1.20         ok
+                               Splinter LZ4     41         41       1.02          >
+                               Roaring LZ4      50         50       1.22         ok
                                Baseline         64         64       1.60         ok
 8 half full blocks             Splinter        308        308       1.00         ok
                                Roaring        2064       2064       6.70         ok
-                               Splinter LZ4    314        314       1.02          >
-                               Roaring LZ4    2078       2078       6.62         ok
+                               Splinter LZ4    310        310       1.01          >
+                               Roaring LZ4    2074       2074       6.69         ok
                                Baseline       4096       4096      13.30         ok
 8 sparse blocks                Splinter         68         68       1.00         ok
                                Roaring          48         48       0.71          <
-                               Splinter LZ4     71         71       1.04          >
-                               Roaring LZ4      54         54       0.76          <
+                               Splinter LZ4     67         67       0.99          <
+                               Roaring LZ4      50         50       0.75          <
                                Baseline         64         64       0.94          <
 64 half full blocks            Splinter       2432       2432       1.00         ok
                                Roaring       16520      16520       6.79         ok
-                               Splinter LZ4   2268       2268       0.93          <
-                               Roaring LZ4   16558      16558       7.30         ok
+                               Splinter LZ4   2264       2264       0.93          <
+                               Roaring LZ4   16554      16554       7.31         ok
                                Baseline      32768      32768      13.47         ok
 64 sparse blocks               Splinter        512        512       1.00         ok
                                Roaring         392        392       0.77          <
-                               Splinter LZ4    331        331       0.65          <
-                               Roaring LZ4     399        399       1.21         ok
+                               Splinter LZ4    327        327       0.64          <
+                               Roaring LZ4     395        395       1.21         ok
                                Baseline        512        512       1.00         ok
 256 half full blocks           Splinter       9440       9440       1.00         ok
                                Roaring       65800      65800       6.97         ok
-                               Splinter LZ4   8748       8748       0.93          <
-                               Roaring LZ4   66050      66050       7.55         ok
+                               Splinter LZ4   8744       8744       0.93          <
+                               Roaring LZ4   66046      66046       7.55         ok
                                Baseline     131072     131072      13.88         ok
 256 sparse blocks              Splinter       1760       1760       1.00         ok
                                Roaring        1288       1288       0.73          <
-                               Splinter LZ4   1053       1053       0.60          <
-                               Roaring LZ4    1298       1298       1.23         ok
+                               Splinter LZ4   1049       1049       0.60          <
+                               Roaring LZ4    1294       1294       1.23         ok
                                Baseline       2048       2048       1.16         ok
 512 half full blocks           Splinter      18872      18872       1.00         ok
                                Roaring      131592     131592       6.97         ok
-                               Splinter LZ4  17417      17417       0.92          <
-                               Roaring LZ4  131545     131545       7.55         ok
+                               Splinter LZ4  17413      17413       0.92          <
+                               Roaring LZ4  131541     131541       7.55         ok
                                Baseline     262144     262144      13.89         ok
 512 sparse blocks              Splinter       3512       3512       1.00         ok
                                Roaring        2568       2568       0.73          <
-                               Splinter LZ4   2044       2044       0.58          <
-                               Roaring LZ4    2584       2584       1.26         ok
+                               Splinter LZ4   2040       2040       0.58          <
+                               Roaring LZ4    2580       2580       1.26         ok
                                Baseline       4096       4096       1.17         ok
 fully dense                    Splinter         84         84       1.00         ok
                                Roaring        8208       8208      97.71         ok
-                               Splinter LZ4     50         50       0.60          <
-                               Roaring LZ4    8246       8246     164.92         ok
+                               Splinter LZ4     46         46       0.55          <
+                               Roaring LZ4    8242       8242     179.17         ok
                                Baseline      16384      16384     195.05         ok
 128/block; dense               Splinter       1172       1172       1.00         ok
                                Roaring        8208       8208       7.00         ok
-                               Splinter LZ4   1161       1161       0.99          <
-                               Roaring LZ4    8246       8246       7.10         ok
+                               Splinter LZ4   1157       1157       0.99          <
+                               Roaring LZ4    8242       8242       7.12         ok
                                Baseline      16384      16384      13.98         ok
 32/block; dense                Splinter       4532       4532       1.00         ok
                                Roaring        8208       8208       1.81         ok
-                               Splinter LZ4   4221       4221       0.93          <
-                               Roaring LZ4    8246       8246       1.95         ok
+                               Splinter LZ4   4217       4217       0.93          <
+                               Roaring LZ4    8242       8242       1.95         ok
                                Baseline      16384      16384       3.62         ok
 16/block; dense                Splinter       4884       4884       1.00         ok
                                Roaring        8208       8208       1.68         ok
-                               Splinter LZ4   4668       4668       0.96          <
-                               Roaring LZ4    8246       8246       1.77         ok
+                               Splinter LZ4   4664       4664       0.95          <
+                               Roaring LZ4    8242       8242       1.77         ok
                                Baseline      16384      16384       3.35         ok
 128/block; sparse mid          Splinter       1358       1358       1.00         ok
                                Roaring        8456       8456       6.23         ok
-                               Splinter LZ4   1342       1342       0.99          <
-                               Roaring LZ4    8493       8493       6.33         ok
+                               Splinter LZ4   1338       1338       0.99          <
+                               Roaring LZ4    8489       8489       6.34         ok
                                Baseline      16384      16384      12.06         ok
 128/block; sparse high         Splinter       1544       1544       1.00         ok
                                Roaring        8456       8456       5.48         ok
-                               Splinter LZ4   1489       1489       0.96          <
-                               Roaring LZ4    8495       8495       5.71         ok
+                               Splinter LZ4   1485       1485       0.96          <
+                               Roaring LZ4    8491       8491       5.72         ok
                                Baseline      16384      16384      10.61         ok
 1/block; sparse mid            Splinter      21774      21774       1.00         ok
                                Roaring       10248      10248       0.47          <
-                               Splinter LZ4  10359      10359       0.48          <
-                               Roaring LZ4   10294      10294       0.99          <
+                               Splinter LZ4  10355      10355       0.48          <
+                               Roaring LZ4   10290      10290       0.99          <
                                Baseline      16384      16384       0.75          <
 1/block; sparse high           Splinter      46344      46344       1.00         ok
                                Roaring       40968      40968       0.88          <
-                               Splinter LZ4  23914      23914       0.52          <
-                               Roaring LZ4   41063      41063       1.72         ok
+                               Splinter LZ4  23910      23910       0.52          <
+                               Roaring LZ4   41059      41059       1.72         ok
                                Baseline      16384      16384       0.35          <
 ```
 

--- a/README.md
+++ b/README.md
@@ -65,103 +65,103 @@ empty                          Splinter          8          8       1.00        
                                Baseline          0          0       0.00          <
 1 element                      Splinter         25         25       1.00         ok
                                Roaring          18         18       0.72          <
-                               Splinter LZ4     18         18       0.72          <
-                               Roaring LZ4      20         20       1.11         ok
+                               Splinter LZ4     29         29       1.16          >
+                               Roaring LZ4      24         24       0.83          <
                                Baseline          4          4       0.16          <
 1 dense block                  Splinter         24         24       1.00         ok
                                Roaring         528        528      22.00         ok
-                               Splinter LZ4     20         20       0.83          <
-                               Roaring LZ4     533        533      26.65         ok
+                               Splinter LZ4     28         28       1.17          >
+                               Roaring LZ4     536        536      19.14         ok
                                Baseline       1024       1024      42.67         ok
 1 half full block              Splinter         56         56       1.00         ok
                                Roaring         272        272       4.86         ok
-                               Splinter LZ4     26         26       0.46          <
-                               Roaring LZ4     276        276      10.62         ok
+                               Splinter LZ4     61         61       1.09          >
+                               Roaring LZ4     279        279       4.57         ok
                                Baseline        512        512       9.14         ok
 1 sparse block                 Splinter         40         40       1.00         ok
                                Roaring          48         48       1.20         ok
-                               Splinter LZ4     37         37       0.93          <
-                               Roaring LZ4      52         52       1.41         ok
+                               Splinter LZ4     45         45       1.12          >
+                               Roaring LZ4      54         54       1.20         ok
                                Baseline         64         64       1.60         ok
 8 half full blocks             Splinter        308        308       1.00         ok
                                Roaring        2064       2064       6.70         ok
-                               Splinter LZ4     70         70       0.23          <
-                               Roaring LZ4    2075       2075      29.64         ok
+                               Splinter LZ4    314        314       1.02          >
+                               Roaring LZ4    2078       2078       6.62         ok
                                Baseline       4096       4096      13.30         ok
 8 sparse blocks                Splinter         68         68       1.00         ok
                                Roaring          48         48       0.71          <
-                               Splinter LZ4     56         56       0.82          <
-                               Roaring LZ4      51         51       0.91          <
+                               Splinter LZ4     71         71       1.04          >
+                               Roaring LZ4      54         54       0.76          <
                                Baseline         64         64       0.94          <
 64 half full blocks            Splinter       2432       2432       1.00         ok
                                Roaring       16520      16520       6.79         ok
-                               Splinter LZ4    117        117       0.05          <
-                               Roaring LZ4    1237       1237      10.57         ok
+                               Splinter LZ4   2268       2268       0.93          <
+                               Roaring LZ4   16558      16558       7.30         ok
                                Baseline      32768      32768      13.47         ok
 64 sparse blocks               Splinter        512        512       1.00         ok
                                Roaring         392        392       0.77          <
-                               Splinter LZ4     84         84       0.16          <
-                               Roaring LZ4     165        165       1.96         ok
+                               Splinter LZ4    331        331       0.65          <
+                               Roaring LZ4     399        399       1.21         ok
                                Baseline        512        512       1.00         ok
 256 half full blocks           Splinter       9440       9440       1.00         ok
                                Roaring       65800      65800       6.97         ok
-                               Splinter LZ4    178        178       0.02          <
-                               Roaring LZ4    2584       2584      14.52         ok
+                               Splinter LZ4   8748       8748       0.93          <
+                               Roaring LZ4   66050      66050       7.55         ok
                                Baseline     131072     131072      13.88         ok
 256 sparse blocks              Splinter       1760       1760       1.00         ok
                                Roaring        1288       1288       0.73          <
-                               Splinter LZ4    122        122       0.07          <
-                               Roaring LZ4     378        378       3.10         ok
+                               Splinter LZ4   1053       1053       0.60          <
+                               Roaring LZ4    1298       1298       1.23         ok
                                Baseline       2048       2048       1.16         ok
 512 half full blocks           Splinter      18872      18872       1.00         ok
                                Roaring      131592     131592       6.97         ok
-                               Splinter LZ4    232        232       0.01          <
-                               Roaring LZ4    3098       3098      13.35         ok
+                               Splinter LZ4  17417      17417       0.92          <
+                               Roaring LZ4  131545     131545       7.55         ok
                                Baseline     262144     262144      13.89         ok
 512 sparse blocks              Splinter       3512       3512       1.00         ok
                                Roaring        2568       2568       0.73          <
-                               Splinter LZ4    142        142       0.04          <
-                               Roaring LZ4     575        575       4.05         ok
+                               Splinter LZ4   2044       2044       0.58          <
+                               Roaring LZ4    2584       2584       1.26         ok
                                Baseline       4096       4096       1.17         ok
 fully dense                    Splinter         84         84       1.00         ok
                                Roaring        8208       8208      97.71         ok
-                               Splinter LZ4     44         44       0.52          <
-                               Roaring LZ4    8244       8244     187.36         ok
+                               Splinter LZ4     50         50       0.60          <
+                               Roaring LZ4    8246       8246     164.92         ok
                                Baseline      16384      16384     195.05         ok
 128/block; dense               Splinter       1172       1172       1.00         ok
                                Roaring        8208       8208       7.00         ok
-                               Splinter LZ4    121        121       0.10          <
-                               Roaring LZ4    8244       8244      68.13         ok
+                               Splinter LZ4   1161       1161       0.99          <
+                               Roaring LZ4    8246       8246       7.10         ok
                                Baseline      16384      16384      13.98         ok
 32/block; dense                Splinter       4532       4532       1.00         ok
                                Roaring        8208       8208       1.81         ok
-                               Splinter LZ4    322        322       0.07          <
-                               Roaring LZ4    8244       8244      25.60         ok
+                               Splinter LZ4   4221       4221       0.93          <
+                               Roaring LZ4    8246       8246       1.95         ok
                                Baseline      16384      16384       3.62         ok
 16/block; dense                Splinter       4884       4884       1.00         ok
                                Roaring        8208       8208       1.68         ok
-                               Splinter LZ4    580        580       0.12          <
-                               Roaring LZ4    8244       8244      14.21         ok
+                               Splinter LZ4   4668       4668       0.96          <
+                               Roaring LZ4    8246       8246       1.77         ok
                                Baseline      16384      16384       3.35         ok
 128/block; sparse mid          Splinter       1358       1358       1.00         ok
                                Roaring        8456       8456       6.23         ok
-                               Splinter LZ4    176        176       0.13          <
-                               Roaring LZ4     563        563       3.20         ok
+                               Splinter LZ4   1342       1342       0.99          <
+                               Roaring LZ4    8493       8493       6.33         ok
                                Baseline      16384      16384      12.06         ok
 128/block; sparse high         Splinter       1544       1544       1.00         ok
                                Roaring        8456       8456       5.48         ok
-                               Splinter LZ4    179        179       0.12          <
-                               Roaring LZ4     563        563       3.15         ok
+                               Splinter LZ4   1489       1489       0.96          <
+                               Roaring LZ4    8495       8495       5.71         ok
                                Baseline      16384      16384      10.61         ok
 1/block; sparse mid            Splinter      21774      21774       1.00         ok
                                Roaring       10248      10248       0.47          <
-                               Splinter LZ4   1191       1191       0.05          <
-                               Roaring LZ4    2138       2138       1.80         ok
+                               Splinter LZ4  10359      10359       0.48          <
+                               Roaring LZ4   10294      10294       0.99          <
                                Baseline      16384      16384       0.75          <
 1/block; sparse high           Splinter      46344      46344       1.00         ok
                                Roaring       40968      40968       0.88          <
-                               Splinter LZ4   1313       1313       0.03          <
-                               Roaring LZ4   32931      32931      25.08         ok
+                               Splinter LZ4  23914      23914       0.52          <
+                               Roaring LZ4   41063      41063       1.72         ok
                                Baseline      16384      16384       0.35          <
 ```
 

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ random/65535                   Splinter     543929     543929       1.00        
                                Splinter LZ4 358584     358584       0.66          <
                                Roaring LZ4  464556     464556       1.30         ok
                                Baseline     262140     262140       0.48          <
+average compression ratio (splinter_lz4 / splinter): 0.74
 ```
 
 ## License

--- a/src/splinter.rs
+++ b/src/splinter.rs
@@ -833,7 +833,7 @@ mod tests {
             "{:30} {:12} {:>6} {:>10} {:>10} {:>10}",
             "test", "bitmap", "size", "expected", "relative", "ok"
         );
-        for report in reports {
+        for report in &reports {
             println!(
                 "{:30} {:12} {:6} {:10} {:>10} {:>10}",
                 report.name,
@@ -909,6 +909,15 @@ mod tests {
                 }
             );
         }
+
+        // calculate average compression ratio (splinter_lz4 / splinter)
+        let avg_ratio = reports
+            .iter()
+            .map(|r| r.splinter_lz4 as f64 / r.splinter.0 as f64)
+            .sum::<f64>()
+            / reports.len() as f64;
+
+        println!("average compression ratio (splinter_lz4 / splinter): {avg_ratio:.2}");
 
         assert!(!fail_test, "compression test failed");
     }

--- a/src/splinter.rs
+++ b/src/splinter.rs
@@ -557,6 +557,13 @@ mod tests {
             let splinter_lz4 = lz4::block::compress(&splinter, None, true).unwrap();
             let roaring_lz4 = lz4::block::compress(&roaring, None, true).unwrap();
 
+            // verify round trip
+            assert_eq!(
+                splinter,
+                lz4::block::decompress(&splinter_lz4, None).unwrap()
+            );
+            assert_eq!(roaring, lz4::block::decompress(&roaring_lz4, None).unwrap());
+
             reports.push(Report {
                 name,
                 baseline: set.len() * std::mem::size_of::<u32>(),

--- a/src/splinter.rs
+++ b/src/splinter.rs
@@ -636,15 +636,18 @@ mod tests {
 
             analyze_compression_patterns(&splinter);
 
-            let splinter_lz4 = lz4::block::compress(&splinter, None, true).unwrap();
-            let roaring_lz4 = lz4::block::compress(&roaring, None, true).unwrap();
+            let splinter_lz4 = lz4::block::compress(&splinter, None, false).unwrap();
+            let roaring_lz4 = lz4::block::compress(&roaring, None, false).unwrap();
 
             // verify round trip
             assert_eq!(
                 splinter,
-                lz4::block::decompress(&splinter_lz4, None).unwrap()
+                lz4::block::decompress(&splinter_lz4, Some(splinter.len() as i32)).unwrap()
             );
-            assert_eq!(roaring, lz4::block::decompress(&roaring_lz4, None).unwrap());
+            assert_eq!(
+                roaring,
+                lz4::block::decompress(&roaring_lz4, Some(roaring.len() as i32)).unwrap()
+            );
 
             reports.push(Report {
                 name,


### PR DESCRIPTION
Test to see how well Splinter's compress using lz4. This is to ensure that if we disable Fjall compression in https://github.com/orbitinghail/graft/issues/85 we aren't leaving too much on the table.

The results of this testing show that Splinter preserves patterns in the underlying data. So if the underlying data is highly compressable, the corresponding Splinter will be highly compressable.

For small sets, lz4 either does nothing or increases the size slightly to account for lz4 overhead.

For most other sets, lz4 is able to compress the offset and cardinality indexes stored in Splinter metadata very reliably. This results in an average compression ratio of around 74% and a base-case ratio of 2% (if the data is fully dense).

Given these results, I'm currently leaning towards continuing to compress Splinters at rest.