### PR TITLE
implement Splinter::range and SplinterRef::range

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 When changing rust code:
 
 - run tests using `cargo nextest run --all-targets`
+- run doctests using `cargo test --doc`
 - run lints using `cargo clippy`
 - ensure the code is formatted correctly using `cargo fmt`
 
@@ -45,3 +46,4 @@ Splinter is low-level systems software. Prioritize safety, performance, and clar
 - Fix any test or type errors until the whole suite is green.
 - Add or update tests for the code you change, even if nobody asked.
 - Ensure benchmarks continue to compile and run.
+- Add docs and doctests to any public functions on `Splinter` or `SplinterRef`, then verify them using `cargo test --doc`

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -1,3 +1,5 @@
+use std::ops::RangeInclusive;
+
 use crate::Segment;
 
 pub const BITMAP_SIZE: usize = 32;
@@ -85,6 +87,22 @@ where
     #[inline]
     fn into_segments(self) -> BitmapSegmentsIter<Self> {
         BitmapSegmentsIter::new(self)
+    }
+
+    #[inline]
+    fn range(&self, range: RangeInclusive<Segment>) -> impl Iterator<Item = Segment> {
+        let r2 = range.clone();
+        self.segments()
+            .skip_while(move |s| !r2.contains(s))
+            .take_while(move |s| range.contains(s))
+    }
+
+    #[inline]
+    fn into_range(self, range: RangeInclusive<Segment>) -> impl Iterator<Item = Segment> {
+        let r2 = range.clone();
+        self.into_segments()
+            .skip_while(move |s| !r2.contains(s))
+            .take_while(move |s| range.contains(s))
     }
 }
 

--- a/src/splinter.rs
+++ b/src/splinter.rs
@@ -526,9 +526,9 @@ struct SegmentRange {
     end: Segment,
 }
 
-impl Into<RangeInclusive<Segment>> for SegmentRange {
-    fn into(self) -> RangeInclusive<Segment> {
-        self.start..=self.end
+impl From<SegmentRange> for RangeInclusive<Segment> {
+    fn from(val: SegmentRange) -> Self {
+        val.start..=val.end
     }
 }
 

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 
 use bytes::Bytes;
 use itertools::Itertools;
+use rand::{SeedableRng, seq::index};
 
 use crate::{Splinter, SplinterRef, util::CopyToOwned};
 
@@ -68,5 +69,66 @@ impl Debug for TestSplinter {
                     .finish()
             }
         }
+    }
+}
+
+pub struct SetGen {
+    rng: rand::rngs::StdRng,
+}
+
+impl SetGen {
+    pub fn new(seed: u64) -> Self {
+        let rng = rand::rngs::StdRng::seed_from_u64(seed);
+        Self { rng }
+    }
+
+    #[track_caller]
+    pub fn distributed(
+        &mut self,
+        high: usize,
+        mid: usize,
+        low: usize,
+        block: usize,
+        expected_len: usize,
+    ) -> Vec<u32> {
+        let mut out = Vec::with_capacity(expected_len);
+        for high in index::sample(&mut self.rng, 256, high) {
+            for mid in index::sample(&mut self.rng, 256, mid) {
+                for low in index::sample(&mut self.rng, 256, low) {
+                    for blk in index::sample(&mut self.rng, 256, block) {
+                        out.push(u32::from_be_bytes([
+                            high as u8, mid as u8, low as u8, blk as u8,
+                        ]));
+                    }
+                }
+            }
+        }
+        out.sort();
+        assert_eq!(out.len(), expected_len);
+        out
+    }
+
+    #[track_caller]
+    pub fn dense(
+        &mut self,
+        high: usize,
+        mid: usize,
+        low: usize,
+        block: usize,
+        expected_len: usize,
+    ) -> Vec<u32> {
+        let out: Vec<u32> = itertools::iproduct!(0..high, 0..mid, 0..low, 0..block)
+            .map(|(a, b, c, d)| u32::from_be_bytes([a as u8, b as u8, c as u8, d as u8]))
+            .collect();
+        assert_eq!(out.len(), expected_len);
+        out
+    }
+
+    pub fn random(&mut self, len: usize) -> Vec<u32> {
+        index::sample(&mut self.rng, u32::MAX as usize, len)
+            .into_iter()
+            .map(|i| i as u32)
+            .sorted()
+            .collect()
     }
 }


### PR DESCRIPTION
This PR implements `Splinter::range` and `SplinterRef::range` which return iterators of keys that are contained by the Splinter. `range` is implemented such that it skips over portions of the trie which do not match the query range. This means that the total number of operations is bounded by the query range rather than the size of the Splinter.