### PR TITLE
Added culprit support to entire decode path

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,5 @@
 # Feature ideas
 
-## Avoid storing the last offset in a TreePartition
-
-The last offset is always 0, so we should be able to avoid storing it. This will optimize the very common case of single child tree partitions offering a large boost in compression performance.
-
 ## Inverted partitions
 
 When a partition is storing more than 50% of it's possible values, we should store it inverted. Thus partitions only grow until they hit 50% of their max storage, and then they start shrinking.

--- a/src/codec/runs_ref.rs
+++ b/src/codec/runs_ref.rs
@@ -1,5 +1,6 @@
 use std::{iter::FusedIterator, ops::RangeInclusive};
 
+use culprit::ResultExt;
 use range_set_blaze::{SortedDisjoint, SortedStarts};
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
@@ -16,8 +17,8 @@ pub struct RunsRef<'a, L: Level> {
 }
 
 impl<'a, L: Level> RunsRef<'a, L> {
-    pub(super) fn from_suffix(data: &'a [u8]) -> Result<Self, DecodeErr> {
-        let (data, runs) = decode_len_from_suffix::<L>(data)?;
+    pub(super) fn from_suffix(data: &'a [u8]) -> culprit::Result<Self, DecodeErr> {
+        let (data, runs) = decode_len_from_suffix::<L>(data).or_into_ctx()?;
         let bytes = runs * size_of::<L::ValueUnaligned>() * 2;
         DecodeErr::ensure_bytes_available(data, bytes)?;
         let range = (data.len() - bytes)..data.len();

--- a/src/partition_kind.rs
+++ b/src/partition_kind.rs
@@ -1,4 +1,4 @@
-use zerocopy::TryFromBytes;
+use zerocopy::{KnownLayout, TryFromBytes};
 
 use crate::partition::Partition;
 
@@ -6,7 +6,7 @@ use crate::level::Level;
 
 /// `PartitionKind` is a one byte bitfield which currently only uses the first
 /// three bits (LE). The remaining bits are reserved for future expansion.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, TryFromBytes)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, TryFromBytes, KnownLayout)]
 #[repr(u8)]
 pub enum PartitionKind {
     #[default]

--- a/src/splinter_ref.rs
+++ b/src/splinter_ref.rs
@@ -1,6 +1,7 @@
 use std::{fmt::Debug, ops::Deref};
 
 use bytes::Bytes;
+use culprit::Culprit;
 use zerocopy::FromBytes;
 
 use crate::{
@@ -235,19 +236,19 @@ impl<B: Deref<Target = [u8]>> SplinterRef<B> {
     ///
     /// let invalid_bytes = vec![0u8; 5]; // Too short
     /// let result = SplinterRef::from_bytes(invalid_bytes);
-    /// assert!(matches!(result, Err(DecodeErr::Length)));
+    /// assert!(matches!(result.unwrap_err().ctx(), DecodeErr::Length));
     /// ```
-    pub fn from_bytes(data: B) -> Result<Self, DecodeErr> {
+    pub fn from_bytes(data: B) -> culprit::Result<Self, DecodeErr> {
         pub(crate) const SPLINTER_V1_MAGIC: [u8; 4] = [0xDA, 0xAE, 0x12, 0xDF];
         if data.len() >= 4
             && data.starts_with(&SPLINTER_V1_MAGIC)
             && !data.ends_with(&SPLINTER_V2_MAGIC)
         {
-            return Err(DecodeErr::SplinterV1);
+            return Err(Culprit::new(DecodeErr::SplinterV1));
         }
 
         if data.len() < Footer::SIZE {
-            return Err(DecodeErr::Length);
+            return Err(Culprit::new(DecodeErr::Length));
         }
         let (partitions, footer) = data.split_at(data.len() - Footer::SIZE);
         Footer::ref_from_bytes(footer)?.validate(partitions)?;

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -19,81 +19,6 @@ use crate::{
     traits::TruncateFrom,
 };
 
-/// Heuristic analyzer: prints patterns found in the data which could be
-/// exploited by lz4 to improve compression
-pub fn analyze_compression_patterns(data: &[u8]) {
-    use std::collections::HashMap;
-
-    let len = data.len();
-    if len == 0 {
-        println!("empty slice");
-        return;
-    }
-    println!("length: {len} bytes");
-
-    // --- zeros ---
-    let (mut zeros, mut longest_run, mut run) = (0usize, 0usize, 0usize);
-    for &b in data {
-        if b == 0 {
-            zeros += 1;
-            run += 1;
-            longest_run = longest_run.max(run);
-        } else {
-            run = 0;
-        }
-    }
-    println!(
-        "zeros: {zeros} ({:.2}%), longest run: {longest_run}",
-        zeros as f64 * 100.0 / len as f64
-    );
-
-    // --- histogram / entropy ---
-    let mut freq = [0u32; 256];
-    for &b in data {
-        freq[b as usize] += 1;
-    }
-    let entropy: f64 = freq
-        .iter()
-        .filter(|&&c| c != 0)
-        .map(|&c| {
-            let p = c as f64 / len as f64;
-            -p * p.log2()
-        })
-        .sum();
-    println!("shannon entropy ≈ {entropy:.3} bits/byte (max 8)");
-
-    // --- repeated 8-byte blocks ---
-    const BLOCK: usize = 8;
-    if len >= BLOCK {
-        let mut map: HashMap<&[u8], u32> = HashMap::new();
-        for chunk in data.chunks_exact(BLOCK) {
-            *map.entry(chunk).or_default() += 1;
-        }
-
-        let mut duplicate_bytes = 0u32;
-        let mut top: Option<(&[u8], u32)> = None;
-
-        for (&k, &v) in map.iter() {
-            if v > 1 {
-                duplicate_bytes += (v - 1) * BLOCK as u32;
-                if top.is_none_or(|(_, max)| v > max) {
-                    top = Some((k, v));
-                }
-            }
-        }
-
-        if let Some((bytes, count)) = top {
-            println!(
-                "repeated 8-byte blocks: {duplicate_bytes} duplicate bytes; most common occurs {count}× (bytes {bytes:02X?})"
-            );
-        } else {
-            println!("no duplicated 8-byte blocks");
-        }
-    }
-
-    println!("analysis complete");
-}
-
 pub fn ratio_to_marks(ratio: f64) -> String {
     let magnitude = if ratio >= 1.0 { ratio } else { 1.0 / ratio };
     let marks = if magnitude >= 4.0 {
@@ -344,4 +269,11 @@ pub fn mksplinter(values: &[u32]) -> Splinter {
 
 pub fn mksplinter_buf(values: &[u32]) -> BytesMut {
     mksplinter(values).encode_to_bytes().try_into_mut().unwrap()
+}
+
+#[macro_export]
+macro_rules! assert_error {
+    ($expr:expr, $err:path$(, $($rest:tt),+)?) => {
+        assert_matches::assert_matches!(($expr).expect_err("expected an error").ctx(), $err $(, $($rest),+)?)
+    };
 }


### PR DESCRIPTION
Helps figure out what's broken when a Splinter fails to decode. Also I
prototyped and discarded the idea of not storing the last offset for a Tree.
After a lot of testing it simply doesn't provide much more compression but makes
the tree ref code more complex.
