### PR TITLE
Bump transitive rand to 0.9.3 (GHSA-cq8v-f236-94qc)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,7 +709,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -747,9 +747,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.3",


### PR DESCRIPTION
`proptest 1.11` pulls in `rand 0.9.2`, which is flagged by GHSA-cq8v-f236-94qc: `rand` is unsound when a custom logger calls `rand::rng()`. It's low severity and only reachable through the optional `proptest` dependency, not our runtime `rand 0.10.1`.

This bumps the lockfile to the patched `0.9.3`. No source changes; full test suite and doctests pass locally.